### PR TITLE
Fix layer numbering direction and layer rename labels

### DIFF
--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -347,11 +347,26 @@ public class Main extends JFrame {
     public void updateToolboxLayerList() {
         if (toolboxFrame != null) {
             List<String> layerNames = paintElements.stream()
-                                                 .map(PaintElement::getDisplayName)
+                                                 .map(this::getEffectiveDisplayName)
                                                  .collect(Collectors.toList());
+            int size = layerNames.size();
+            for (int i = 0; i < size; i++) {
+                layerNames.set(i, String.format("[%d] %s", size - 1 - i, layerNames.get(i)));
+            }
             Collections.reverse(layerNames); // To display top layer at the top of the list
             toolboxFrame.updateLayersList(layerNames);
         }
+    }
+
+    private String getEffectiveDisplayName(PaintElement element) {
+        if (element == null) {
+            return "Unnamed";
+        }
+        String displayName = element.getDisplayName();
+        if (displayName == null || displayName.trim().isEmpty()) {
+            return element.getName();
+        }
+        return displayName;
     }
 
     public void internalAddElementToList(PaintElement element, int index) {
@@ -462,10 +477,8 @@ public class Main extends JFrame {
         String uniqueDisplayName = generateUniqueDisplayName(duplicatedElement.getName());
         duplicatedElement.setDisplayName(uniqueDisplayName);
         paintElements.add(0, duplicatedElement);
-        if (toolboxFrame != null) {
-            toolboxFrame.addLayerToList(uniqueDisplayName, 0);
-            toolboxFrame.selectLayerInList(0);
-        }
+        updateToolboxLayerList();
+        if (toolboxFrame != null) toolboxFrame.selectLayerInList(0);
         repaintDrawingPanel();
         setLastActionStatus("Duplicated '" + uniqueDisplayName + "'");
         logger.info("Element '{}' duplicated as '{}' at offset ({}, {})", originalElement.getDisplayName(), uniqueDisplayName, offsetX, offsetY);

--- a/src/main/java/app/ToolboxFrame.java
+++ b/src/main/java/app/ToolboxFrame.java
@@ -360,7 +360,8 @@ public class ToolboxFrame extends JFrame {
         editBtn.addActionListener(e -> {
             int selectedIndex = layersList.getSelectedIndex();
             if (selectedIndex != -1) {
-                String currentName = layersModel.getElementAt(selectedIndex);
+                String currentLabel = layersModel.getElementAt(selectedIndex);
+                String currentName = stripLayerIndexPrefix(currentLabel);
                 Object newNameInputObj = JOptionPane.showInputDialog(ToolboxFrame.this, "Enter new layer name:", "Edit Layer Name", JOptionPane.PLAIN_MESSAGE, null, null, currentName);
 
                 if (newNameInputObj != null) { // User clicked OK or entered text
@@ -369,7 +370,8 @@ public class ToolboxFrame extends JFrame {
                         // Check for name uniqueness (optional, Main.java could also enforce this or handle conflicts)
                         boolean nameExists = false;
                         for (int i = 0; i < layersModel.getSize(); i++) {
-                            if (i != selectedIndex && layersModel.getElementAt(i).equals(newName)) {
+                            String existingName = stripLayerIndexPrefix(layersModel.getElementAt(i));
+                            if (i != selectedIndex && existingName.equals(newName)) {
                                 nameExists = true;
                                 break;
                             }
@@ -377,12 +379,11 @@ public class ToolboxFrame extends JFrame {
                         if (nameExists) {
                             JOptionPane.showMessageDialog(ToolboxFrame.this, "Layer name '" + newName + "' already exists.", "Name Conflict", JOptionPane.ERROR_MESSAGE);
                         } else {
-                            layersModel.setElementAt(newName, selectedIndex);
                             // Notify Main.java to update the PaintElement's displayName
                             if (mainFrame != null) {
                                 mainFrame.updatePaintElementDisplayName(selectedIndex, newName);
                             }
-                            logger.info("Edited layer: '" + currentName + "' to '" + newName + "' at JList index " + selectedIndex);
+                            logger.info("Edited layer: '" + currentLabel + "' to '" + newName + "' at JList index " + selectedIndex);
                         }
                     } else if (newName.isEmpty()) {
                         JOptionPane.showMessageDialog(ToolboxFrame.this, "Layer name cannot be empty.", "Invalid Name", JOptionPane.ERROR_MESSAGE);
@@ -925,6 +926,11 @@ public class ToolboxFrame extends JFrame {
     // Overloaded method to add to the top (index 0) by default, for new shapes
     public void addLayerToList(String layerName) {
         addLayerToList(layerName, 0);
+    }
+
+    private String stripLayerIndexPrefix(String label) {
+        if (label == null) return "";
+        return label.replaceFirst("^\\\\[\\\\d+\\\\]\\\\s*", "").trim();
     }
 
     public void moveLayerToTopInList(int oldIndex) {


### PR DESCRIPTION
This pull request enhances the way layer names are displayed and edited in the toolbox, improving both usability and consistency between the internal data model and the UI. The most significant changes involve prefixing layer names with their indices in the UI, ensuring robust handling of display names, and improving the logic for editing and validating layer names.

**Improvements to Layer Name Display and Handling:**

* Layer names shown in the toolbox are now prefixed with their index (e.g., "[0] LayerName"), making layer order clearer to users. The index is dynamically calculated so the topmost layer is always [0]. (`Main.java`, `updateToolboxLayerList`)
* A new helper method, `getEffectiveDisplayName`, ensures that each layer always has a non-empty display name by falling back to the element's name if the display name is missing or blank. (`Main.java`)

**Consistency and Robustness in Layer Name Editing:**

* When editing a layer name, the UI now strips off the index prefix before presenting the name to the user and when checking for uniqueness, preventing accidental conflicts due to prefixed labels. (`ToolboxFrame.java`, `valueChanged`, `stripLayerIndexPrefix`) [[1]](diffhunk://#diff-37b97375138a8b2d6ab955f25eea595c38c9f215c72541dda46f1b9c0309a231L363-R364) [[2]](diffhunk://#diff-37b97375138a8b2d6ab955f25eea595c38c9f215c72541dda46f1b9c0309a231L372-R386) [[3]](diffhunk://#diff-37b97375138a8b2d6ab955f25eea595c38c9f215c72541dda46f1b9c0309a231R931-R935)
* The logic for updating the toolbox after duplicating a layer is simplified: the full list is refreshed and the new layer is selected, ensuring correct display and selection. (`Main.java`, `duplicatePaintElement`)