### PR TITLE
Update drawing tools and panel behavior

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,7 @@
       "mainClass": "app.Main",
       "projectName": "pfeasel-paint-creator",
       "cwd": "${workspaceFolder}",
+      "terminateDebuggee": true,
       "postDebugTask": "Kill PF Easel"
     }
   ]

--- a/src/main/java/app/CanvasRenderer.java
+++ b/src/main/java/app/CanvasRenderer.java
@@ -7,7 +7,9 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.awt.Stroke;
+import java.awt.geom.GeneralPath;
 import java.awt.image.BufferedImage;
+import java.util.ArrayList;
 import java.util.List;
 
 import paintcomponents.PaintElement;
@@ -31,7 +33,10 @@ public class CanvasRenderer {
             Point endPoint,
             Rectangle currentDrawingRectangle,
             boolean isDrawingPolygon,
-            List<Point> currentPolygonPoints) {
+            List<Point> currentPolygonPoints,
+            List<Point> currentFreehandPoints,
+            boolean isDrawingBezier,
+            List<Point> currentBezierPoints) {
 
         if (antiAliasingActive) {
             g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
@@ -173,6 +178,82 @@ public class CanvasRenderer {
                 g2d.drawLine(prevPoint.x, prevPoint.y, endPoint.x, endPoint.y);
             }
         }
+
+        // Freehand in-progress preview
+        if (currentFreehandPoints != null && currentFreehandPoints.size() >= 2 && toolboxFrame != null
+                && toolboxFrame.getSelectedTool() == ToolboxFrame.ToolType.FREEHAND) {
+            Color strokeColor = toolboxFrame.isStrokeEnabled() ? toolboxFrame.getStrokeColor() : Color.BLACK;
+            float strokeWidth = (float) toolboxFrame.getCurrentStrokeWidth();
+            g2d.setColor(strokeColor);
+            g2d.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+            GeneralPath previewPath = new GeneralPath();
+            Point fp = currentFreehandPoints.get(0);
+            previewPath.moveTo(fp.x, fp.y);
+            for (int i = 1; i < currentFreehandPoints.size(); i++) {
+                Point fp2 = currentFreehandPoints.get(i);
+                previewPath.lineTo(fp2.x, fp2.y);
+            }
+            g2d.draw(previewPath);
+        }
+
+        // Bezier in-progress preview
+        if (isDrawingBezier && currentBezierPoints != null && !currentBezierPoints.isEmpty() && toolboxFrame != null) {
+            Color strokeColor = toolboxFrame.isStrokeEnabled() ? toolboxFrame.getStrokeColor() : Color.GRAY;
+            float strokeWidth = (float) toolboxFrame.getCurrentStrokeWidth();
+
+            // Build preview list: placed anchors + live mouse position as tentative next point
+            List<Point> previewPoints = new ArrayList<>(currentBezierPoints);
+            if (endPoint != null) {
+                previewPoints.add(endPoint);
+            }
+
+            if (previewPoints.size() >= 2) {
+                g2d.setColor(strokeColor);
+                g2d.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+                g2d.draw(buildCatmullRomPath(previewPoints, 0, 0));
+            } else if (endPoint != null) {
+                // Only one placed point — dashed line to mouse
+                Stroke oldStroke = g2d.getStroke();
+                float[] dash = {4f, 4f};
+                g2d.setColor(Color.GRAY);
+                g2d.setStroke(new BasicStroke(1f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10f, dash, 0f));
+                Point sole = currentBezierPoints.get(0);
+                g2d.drawLine(sole.x, sole.y, endPoint.x, endPoint.y);
+                g2d.setStroke(oldStroke);
+            }
+
+            // Draw anchor dots for placed points
+            for (int i = 0; i < currentBezierPoints.size(); i++) {
+                Point bp = currentBezierPoints.get(i);
+                if (i == 0) {
+                    g2d.setColor(Color.GREEN);
+                    g2d.fillOval(bp.x - 4, bp.y - 4, 8, 8);
+                } else {
+                    g2d.setColor(Color.BLUE);
+                    g2d.fillOval(bp.x - 3, bp.y - 3, 6, 6);
+                }
+            }
+        }
+    }
+
+    private static GeneralPath buildCatmullRomPath(List<Point> pts, int dx, int dy) {
+        GeneralPath path = new GeneralPath();
+        if (pts.size() < 2) return path;
+        int n = pts.size();
+        Point first = pts.get(0);
+        path.moveTo(first.x + dx, first.y + dy);
+        for (int i = 0; i < n - 1; i++) {
+            Point p0 = pts.get(Math.max(0, i - 1));
+            Point p1 = pts.get(i);
+            Point p2 = pts.get(i + 1);
+            Point p3 = pts.get(Math.min(n - 1, i + 2));
+            double cp1x = p1.x + (p2.x - p0.x) / 6.0;
+            double cp1y = p1.y + (p2.y - p0.y) / 6.0;
+            double cp2x = p2.x - (p3.x - p1.x) / 6.0;
+            double cp2y = p2.y - (p3.y - p1.y) / 6.0;
+            path.curveTo(cp1x + dx, cp1y + dy, cp2x + dx, cp2y + dy, p2.x + dx, p2.y + dy);
+        }
+        return path;
     }
 
     private void drawResizeHandles(Graphics2D g2d, Rectangle bounds) {

--- a/src/main/java/app/DrawingPanel.java
+++ b/src/main/java/app/DrawingPanel.java
@@ -7,6 +7,8 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
@@ -24,6 +26,7 @@ import paintcomponents.TextElement;
 
 public class DrawingPanel extends JPanel {
     private static final Logger logger = LoggerFactory.getLogger(DrawingPanel.class);
+    private static final int FREEHAND_MIN_DIST = 3;
 
     private final Main host;
     private final DrawingController drawingController;
@@ -36,6 +39,10 @@ public class DrawingPanel extends JPanel {
     private Rectangle currentDrawingRectangle;
     private final List<Point> currentPolygonPoints = new ArrayList<>();
     private boolean isDrawingPolygon = false;
+    private final List<Point> currentFreehandPoints = new ArrayList<>();
+    private boolean isDrawingFreehand = false;
+    private final List<Point> currentBezierPoints = new ArrayList<>();
+    private boolean isDrawingBezier = false;
 
     public DrawingPanel(Main host, DrawingController drawingController, CanvasRenderer canvasRenderer, ShapeCreationService shapeCreationService) {
         this.host = host;
@@ -61,7 +68,7 @@ public class DrawingPanel extends JPanel {
                     setCursor(java.awt.Cursor.getDefaultCursor());
                 }
 
-                if (selectedTool == ToolboxFrame.ToolType.POLYGON) {
+                if (selectedTool == ToolboxFrame.ToolType.POLYGON || selectedTool == ToolboxFrame.ToolType.BEZIER) {
                     endPoint = host.isSnapToGridActive() && host.getGridManager().isGridVisible()
                             ? snapPointToGrid(currentMousePoint)
                             : currentMousePoint;
@@ -90,6 +97,12 @@ public class DrawingPanel extends JPanel {
                         && dragStartPoint != null) {
                     currentDrawingRectangle = shapeCreationService.calculateBounds(dragStartPoint, endPoint);
                     repaint();
+                } else if (selectedTool == ToolboxFrame.ToolType.FREEHAND && isDrawingFreehand) {
+                    Point last = currentFreehandPoints.isEmpty() ? null : currentFreehandPoints.get(currentFreehandPoints.size() - 1);
+                    if (last == null || endPoint.distance(last) >= FREEHAND_MIN_DIST) {
+                        currentFreehandPoints.add(new Point(endPoint));
+                    }
+                    repaint();
                 }
             }
         });
@@ -111,6 +124,7 @@ public class DrawingPanel extends JPanel {
                     return;
                 }
 
+                requestFocusInWindow();
                 drawingController.clearSelection(DrawingPanel.this);
                 setCursor(java.awt.Cursor.getDefaultCursor());
 
@@ -127,6 +141,10 @@ public class DrawingPanel extends JPanel {
                         || selectedTool == ToolboxFrame.ToolType.CIRCLE) {
                     dragStartPoint = startPoint;
                     endPoint = startPoint;
+                } else if (selectedTool == ToolboxFrame.ToolType.FREEHAND) {
+                    isDrawingFreehand = true;
+                    currentFreehandPoints.clear();
+                    currentFreehandPoints.add(new Point(startPoint));
                 }
             }
 
@@ -143,6 +161,22 @@ public class DrawingPanel extends JPanel {
                 endPoint = host.isSnapToGridActive() && host.getGridManager().isGridVisible()
                         ? snapPointToGrid(e.getPoint())
                         : e.getPoint();
+
+                if (selectedTool == ToolboxFrame.ToolType.FREEHAND) {
+                    if (isDrawingFreehand && currentFreehandPoints.size() >= 2 && toolboxFrame != null) {
+                        PaintElement fe = shapeCreationService.createFreehandElement(currentFreehandPoints, toolboxFrame);
+                        fe.setShadow(toolboxFrame.isShadowEnabled());
+                        String uniqueDisplayName = host.generateUniqueDisplayName(fe.getName());
+                        fe.setDisplayName(uniqueDisplayName);
+                        host.addPaintElement(fe);
+                        host.setLastActionStatus("Drew " + uniqueDisplayName);
+                    }
+                    currentFreehandPoints.clear();
+                    isDrawingFreehand = false;
+                    startPoint = null;
+                    repaint();
+                    return;
+                }
 
                 if (startPoint == null) {
                     return;
@@ -211,6 +245,16 @@ public class DrawingPanel extends JPanel {
                     }
                 }
 
+                if (isDrawingBezier && selectedTool != ToolboxFrame.ToolType.BEZIER) {
+                    if (currentBezierPoints.size() >= 2) {
+                        finalizeBezier();
+                    } else {
+                        isDrawingBezier = false;
+                        currentBezierPoints.clear();
+                        repaint();
+                    }
+                }
+
                 if (selectedTool == ToolboxFrame.ToolType.TEXT) {
                     if (toolboxFrame == null) {
                         return;
@@ -256,6 +300,51 @@ public class DrawingPanel extends JPanel {
                         repaint();
                     }
                 }
+
+                if (selectedTool == ToolboxFrame.ToolType.BEZIER) {
+                    isDrawingBezier = true;
+                    if (e.getButton() == MouseEvent.BUTTON3) {
+                        // Right-click: finalize or cancel
+                        if (currentBezierPoints.size() >= 2) {
+                            finalizeBezier();
+                        } else {
+                            isDrawingBezier = false;
+                            currentBezierPoints.clear();
+                            endPoint = null;
+                            repaint();
+                        }
+                        return;
+                    }
+                    if (e.getButton() == MouseEvent.BUTTON1) {
+                        if (e.getClickCount() == 1) {
+                            currentBezierPoints.add(clickedPoint);
+                        } else if (e.getClickCount() == 2 && currentBezierPoints.size() >= 2) {
+                            finalizeBezier();
+                            return;
+                        }
+                        repaint();
+                    }
+                }
+            }
+        });
+        addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                logger.info("[KeyAdapter] keyPressed: code={} char='{}' isDrawingBezier={} isDrawingFreehand={}",
+                        e.getKeyCode(), e.getKeyChar(), isDrawingBezier, isDrawingFreehand);
+                if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
+                    if (isDrawingBezier) {
+                        isDrawingBezier = false;
+                        currentBezierPoints.clear();
+                        endPoint = null;
+                        repaint();
+                    } else if (isDrawingFreehand) {
+                        isDrawingFreehand = false;
+                        currentFreehandPoints.clear();
+                        startPoint = null;
+                        repaint();
+                    }
+                }
             }
         });
     }
@@ -277,6 +366,26 @@ public class DrawingPanel extends JPanel {
 
         currentPolygonPoints.clear();
         isDrawingPolygon = false;
+        startPoint = null;
+        endPoint = null;
+        repaint();
+    }
+
+    private void finalizeBezier() {
+        if (currentBezierPoints.size() >= 2) {
+            ToolboxFrame toolboxFrame = host.getToolboxFrame();
+            if (toolboxFrame == null) {
+                return;
+            }
+            PaintElement bezier = shapeCreationService.createBezierElement(currentBezierPoints, toolboxFrame);
+            bezier.setShadow(toolboxFrame.isShadowEnabled());
+            String uniqueDisplayName = host.generateUniqueDisplayName(bezier.getName());
+            bezier.setDisplayName(uniqueDisplayName);
+            host.addPaintElement(bezier);
+            host.setLastActionStatus("Drew bezier curve '" + uniqueDisplayName + "' with " + currentBezierPoints.size() + " points");
+        }
+        currentBezierPoints.clear();
+        isDrawingBezier = false;
         startPoint = null;
         endPoint = null;
         repaint();
@@ -308,6 +417,9 @@ public class DrawingPanel extends JPanel {
                 endPoint,
                 currentDrawingRectangle,
                 isDrawingPolygon,
-                currentPolygonPoints);
+                currentPolygonPoints,
+                currentFreehandPoints,
+                isDrawingBezier,
+                currentBezierPoints);
     }
 }

--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -268,6 +268,8 @@ public class Main extends JFrame {
             case CIRCLE:
             case LINE:
             case POLYGON:
+            case FREEHAND:
+            case BEZIER:
             case TEXT:
             case IMAGE_URL:
             case IMAGE_LOCAL:

--- a/src/main/java/app/ShapeCreationService.java
+++ b/src/main/java/app/ShapeCreationService.java
@@ -4,9 +4,14 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 
+import paintcomponents.BezierElement;
 import paintcomponents.CircleElement;
+import paintcomponents.FreehandElement;
 import paintcomponents.LineElement;
 import paintcomponents.PaintElement;
 import paintcomponents.PolygonElement;
@@ -108,5 +113,61 @@ public class ShapeCreationService {
                 strokeWidth,
                 toolboxFrame.isFillEnabled(),
                 toolboxFrame.isStrokeEnabled());
+    }
+
+    public FreehandElement createFreehandElement(List<Point> points, ToolboxFrame toolboxFrame) {
+        Color strokeColor = toolboxFrame.isStrokeEnabled() ? toolboxFrame.getStrokeColor() : Color.BLACK;
+        float strokeWidth = (float) toolboxFrame.getCurrentStrokeWidth();
+        List<Point> simplified = douglasPeucker(points, 2.0);
+        return new FreehandElement(simplified, strokeColor, strokeWidth);
+    }
+
+    public BezierElement createBezierElement(List<Point> points, ToolboxFrame toolboxFrame) {
+        Color strokeColor = toolboxFrame.isStrokeEnabled() ? toolboxFrame.getStrokeColor() : Color.BLACK;
+        float strokeWidth = (float) toolboxFrame.getCurrentStrokeWidth();
+        return new BezierElement(points, strokeColor, strokeWidth);
+    }
+
+    /**
+     * Iterative Douglas-Peucker polyline simplification.
+     * Removes points that deviate less than {@code epsilon} pixels from the
+     * straight line between their neighbours.
+     */
+    private static List<Point> douglasPeucker(List<Point> points, double epsilon) {
+        if (points.size() < 3) return new ArrayList<>(points);
+        boolean[] keep = new boolean[points.size()];
+        keep[0] = true;
+        keep[points.size() - 1] = true;
+        Deque<int[]> stack = new ArrayDeque<>();
+        stack.push(new int[]{0, points.size() - 1});
+        while (!stack.isEmpty()) {
+            int[] range = stack.pop();
+            int lo = range[0], hi = range[1];
+            double maxDist = 0;
+            int maxIdx = lo;
+            Point a = points.get(lo);
+            Point b = points.get(hi);
+            for (int i = lo + 1; i < hi; i++) {
+                double d = pointToLineDistance(points.get(i), a, b);
+                if (d > maxDist) { maxDist = d; maxIdx = i; }
+            }
+            if (maxDist > epsilon) {
+                keep[maxIdx] = true;
+                if (maxIdx - lo > 1) stack.push(new int[]{lo, maxIdx});
+                if (hi - maxIdx > 1) stack.push(new int[]{maxIdx, hi});
+            }
+        }
+        List<Point> result = new ArrayList<>();
+        for (int i = 0; i < points.size(); i++) {
+            if (keep[i]) result.add(points.get(i));
+        }
+        return result;
+    }
+
+    private static double pointToLineDistance(Point p, Point a, Point b) {
+        double dx = b.x - a.x, dy = b.y - a.y;
+        if (dx == 0 && dy == 0) return p.distance(a);
+        double t = ((p.x - a.x) * dx + (p.y - a.y) * dy) / (dx * dx + dy * dy);
+        return Math.hypot(p.x - (a.x + t * dx), p.y - (a.y + t * dy));
     }
 }

--- a/src/main/java/app/ToolboxFrame.java
+++ b/src/main/java/app/ToolboxFrame.java
@@ -23,7 +23,7 @@ public class ToolboxFrame extends JFrame {
     private static final Logger logger = LoggerFactory.getLogger(ToolboxFrame.class);
     // Define an enum for the tools
     public enum ToolType {
-        SELECT, TEXT, RECTANGLE, ROUND_RECTANGLE, CIRCLE, LINE, POLYGON, IMAGE_URL, IMAGE_LOCAL, MOVE // Added SELECT
+        SELECT, TEXT, RECTANGLE, ROUND_RECTANGLE, CIRCLE, LINE, POLYGON, FREEHAND, BEZIER, IMAGE_URL, IMAGE_LOCAL, MOVE
     }
 
     private ToolType selectedTool = ToolType.SELECT; // Default tool changed to SELECT
@@ -89,15 +89,17 @@ public class ToolboxFrame extends JFrame {
         sidebar.setPreferredSize(new Dimension(40, 0));
 
         // Tool buttons
-        JToggleButton textTool = createToolButton("Text", "/img/ui/material-symbols--font-download-outline-sharp.png", ToolType.TEXT);
-        JToggleButton rectTool = createToolButton("Rectangle", "/img/ui/material-symbols--rectangle-outline.png", ToolType.RECTANGLE);
-        JToggleButton roundRectTool = createToolButton("Rounded Rectangle", "/img/ui/material-symbols--rectangle-outline-rounded.png", ToolType.ROUND_RECTANGLE);
-        JToggleButton circleTool = createToolButton("Circle", "/img/ui/material-symbols--circle-outline.png", ToolType.CIRCLE);
-        JToggleButton lineTool = createToolButton("Line", "/img/ui/material-symbols--line-end.png", ToolType.LINE);
-        JToggleButton polygonTool = createToolButton("Polygon", "/img/ui/uil--polygon.png", ToolType.POLYGON);
-        JToggleButton imageUrlTool = createToolButton("Image URL", "/img/ui/material-symbols--image.png", ToolType.IMAGE_URL);
-        JToggleButton imageLocalTool = createToolButton("Local Image", "/img/ui/material-symbols-light--image-search.png", ToolType.IMAGE_LOCAL);
-        JToggleButton moveTool = createToolButton("Move", "/img/ui/mdi--cursor-move.png", ToolType.MOVE);
+        JToggleButton textTool = createToolButton("Text", "/img/ui/text.png", ToolType.TEXT);
+        JToggleButton rectTool = createToolButton("Rectangle", "/img/ui/rectangle.png", ToolType.RECTANGLE);
+        JToggleButton roundRectTool = createToolButton("Rounded Rectangle", "/img/ui/rectangle-rounded.png", ToolType.ROUND_RECTANGLE);
+        JToggleButton circleTool = createToolButton("Circle", "/img/ui/circle.png", ToolType.CIRCLE);
+        JToggleButton lineTool = createToolButton("Line", "/img/ui/line.png", ToolType.LINE);
+        JToggleButton polygonTool = createToolButton("Polygon", "/img/ui/polygon.png", ToolType.POLYGON);
+        JToggleButton imageUrlTool = createToolButton("Image URL", "/img/ui/image.png", ToolType.IMAGE_URL);
+        JToggleButton imageLocalTool = createToolButton("Local Image", "/img/ui/image-search.png", ToolType.IMAGE_LOCAL);
+        JToggleButton moveTool = createToolButton("Move", "/img/ui/cursor-move.png", ToolType.MOVE);
+        JToggleButton freehandTool = createToolButton("Freehand", "/img/ui/pen.png", ToolType.FREEHAND);
+        JToggleButton bezierTool = createToolButton("Bezier Curve", "/img/ui/bezier-curve.png", ToolType.BEZIER);
 
         // Add tool buttons to sidebar
         registerToolButton(sidebar, ToolType.TEXT, textTool);
@@ -106,6 +108,8 @@ public class ToolboxFrame extends JFrame {
         registerToolButton(sidebar, ToolType.CIRCLE, circleTool);
         registerToolButton(sidebar, ToolType.LINE, lineTool);
         registerToolButton(sidebar, ToolType.POLYGON, polygonTool);
+        registerToolButton(sidebar, ToolType.FREEHAND, freehandTool);
+        registerToolButton(sidebar, ToolType.BEZIER, bezierTool);
         registerToolButton(sidebar, ToolType.IMAGE_URL, imageUrlTool);
         registerToolButton(sidebar, ToolType.IMAGE_LOCAL, imageLocalTool);
         registerToolButton(sidebar, ToolType.MOVE, moveTool);

--- a/src/main/java/paintcomponents/BezierElement.java
+++ b/src/main/java/paintcomponents/BezierElement.java
@@ -1,0 +1,120 @@
+package paintcomponents;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.geom.GeneralPath;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BezierElement implements PaintElement {
+    private List<Point> points;
+    private Color strokeColor;
+    private float strokeWidth;
+    private boolean hasShadow;
+    private String displayName;
+
+    public BezierElement(List<Point> points, Color strokeColor, float strokeWidth) {
+        this.points = new ArrayList<>(points);
+        this.strokeColor = strokeColor;
+        this.strokeWidth = strokeWidth;
+        this.hasShadow = false;
+    }
+
+    /**
+     * Builds a smooth Catmull-Rom spline path through all stored anchor points,
+     * offset by (dx, dy).
+     */
+    private GeneralPath buildPath(int dx, int dy) {
+        GeneralPath path = new GeneralPath();
+        if (points.size() < 2) return path;
+        int n = points.size();
+        Point first = points.get(0);
+        path.moveTo(first.x + dx, first.y + dy);
+        for (int i = 0; i < n - 1; i++) {
+            Point p0 = points.get(Math.max(0, i - 1));
+            Point p1 = points.get(i);
+            Point p2 = points.get(i + 1);
+            Point p3 = points.get(Math.min(n - 1, i + 2));
+            // Catmull-Rom to cubic Bezier control point conversion
+            double cp1x = p1.x + (p2.x - p0.x) / 6.0;
+            double cp1y = p1.y + (p2.y - p0.y) / 6.0;
+            double cp2x = p2.x - (p3.x - p1.x) / 6.0;
+            double cp2y = p2.y - (p3.y - p1.y) / 6.0;
+            path.curveTo(cp1x + dx, cp1y + dy, cp2x + dx, cp2y + dy, p2.x + dx, p2.y + dy);
+        }
+        return path;
+    }
+
+    @Override
+    public void draw(Graphics2D g2d) {
+        if (strokeColor == null || strokeWidth <= 0 || points.size() < 2) return;
+        g2d.setColor(strokeColor);
+        g2d.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        g2d.draw(buildPath(0, 0));
+    }
+
+    @Override
+    public void drawShadow(Graphics2D g2d, Color shadowColor, int shadowXOffset, int shadowYOffset) {
+        if (!hasShadow || shadowColor == null || strokeWidth <= 0 || points.size() < 2) return;
+        g2d.setColor(shadowColor);
+        g2d.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        g2d.draw(buildPath(shadowXOffset, shadowYOffset));
+    }
+
+    @Override
+    public boolean contains(Point p) {
+        if (points.size() < 2) return false;
+        GeneralPath path = buildPath(0, 0);
+        float hitWidth = Math.max(strokeWidth + 6, 8);
+        return new BasicStroke(hitWidth).createStrokedShape(path).contains(p);
+    }
+
+    @Override
+    public void setPosition(int x, int y) {
+        if (points.isEmpty()) return;
+        Rectangle b = getBounds();
+        int dx = x - b.x;
+        int dy = y - b.y;
+        List<Point> translated = new ArrayList<>();
+        for (Point pt : points) translated.add(new Point(pt.x + dx, pt.y + dy));
+        points = translated;
+    }
+
+    @Override
+    public Point getPosition() {
+        return new Point(getBounds().x, getBounds().y);
+    }
+
+    @Override
+    public Rectangle getBounds() {
+        if (points.isEmpty()) return new Rectangle(0, 0, 0, 0);
+        if (points.size() == 1) return new Rectangle(points.get(0).x, points.get(0).y, 0, 0);
+        return buildPath(0, 0).getBounds();
+    }
+
+    @Override
+    public boolean hasShadow() { return hasShadow; }
+
+    @Override
+    public void setShadow(boolean hasShadow) { this.hasShadow = hasShadow; }
+
+    @Override
+    public String getName() { return "Bezier"; }
+
+    @Override
+    public String getDisplayName() { return displayName; }
+
+    @Override
+    public void setDisplayName(String name) { this.displayName = name; }
+
+    @Override
+    public PaintElement duplicate() {
+        BezierElement copy = new BezierElement(points, strokeColor, strokeWidth);
+        copy.setShadow(hasShadow);
+        copy.setDisplayName(displayName);
+        return copy;
+    }
+}

--- a/src/main/java/paintcomponents/FreehandElement.java
+++ b/src/main/java/paintcomponents/FreehandElement.java
@@ -1,0 +1,119 @@
+package paintcomponents;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.geom.GeneralPath;
+import java.awt.geom.Line2D;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FreehandElement implements PaintElement {
+    private List<Point> points;
+    private Color strokeColor;
+    private float strokeWidth;
+    private boolean hasShadow;
+    private String displayName;
+
+    public FreehandElement(List<Point> points, Color strokeColor, float strokeWidth) {
+        this.points = new ArrayList<>(points);
+        this.strokeColor = strokeColor;
+        this.strokeWidth = strokeWidth;
+        this.hasShadow = false;
+    }
+
+    private GeneralPath buildPath(int dx, int dy) {
+        GeneralPath path = new GeneralPath();
+        if (points.size() < 2) return path;
+        Point first = points.get(0);
+        path.moveTo(first.x + dx, first.y + dy);
+        for (int i = 1; i < points.size(); i++) {
+            Point p = points.get(i);
+            path.lineTo(p.x + dx, p.y + dy);
+        }
+        return path;
+    }
+
+    @Override
+    public void draw(Graphics2D g2d) {
+        if (strokeColor == null || strokeWidth <= 0 || points.size() < 2) return;
+        g2d.setColor(strokeColor);
+        g2d.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        g2d.draw(buildPath(0, 0));
+    }
+
+    @Override
+    public void drawShadow(Graphics2D g2d, Color shadowColor, int shadowXOffset, int shadowYOffset) {
+        if (!hasShadow || shadowColor == null || strokeWidth <= 0 || points.size() < 2) return;
+        g2d.setColor(shadowColor);
+        g2d.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+        g2d.draw(buildPath(shadowXOffset, shadowYOffset));
+    }
+
+    @Override
+    public boolean contains(Point p) {
+        for (int i = 1; i < points.size(); i++) {
+            Point a = points.get(i - 1);
+            Point b = points.get(i);
+            Line2D seg = new Line2D.Double(a.x, a.y, b.x, b.y);
+            if (seg.ptSegDist(p) <= strokeWidth / 2.0 + 3) return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void setPosition(int x, int y) {
+        if (points.isEmpty()) return;
+        Rectangle b = getBounds();
+        int dx = x - b.x;
+        int dy = y - b.y;
+        List<Point> translated = new ArrayList<>();
+        for (Point pt : points) translated.add(new Point(pt.x + dx, pt.y + dy));
+        points = translated;
+    }
+
+    @Override
+    public Point getPosition() {
+        return new Point(getBounds().x, getBounds().y);
+    }
+
+    @Override
+    public Rectangle getBounds() {
+        if (points.isEmpty()) return new Rectangle(0, 0, 0, 0);
+        int minX = Integer.MAX_VALUE, minY = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE, maxY = Integer.MIN_VALUE;
+        for (Point p : points) {
+            if (p.x < minX) minX = p.x;
+            if (p.y < minY) minY = p.y;
+            if (p.x > maxX) maxX = p.x;
+            if (p.y > maxY) maxY = p.y;
+        }
+        int buf = (int) Math.ceil(strokeWidth / 2.0) + 1;
+        return new Rectangle(minX - buf, minY - buf, maxX - minX + 2 * buf, maxY - minY + 2 * buf);
+    }
+
+    @Override
+    public boolean hasShadow() { return hasShadow; }
+
+    @Override
+    public void setShadow(boolean hasShadow) { this.hasShadow = hasShadow; }
+
+    @Override
+    public String getName() { return "Freehand"; }
+
+    @Override
+    public String getDisplayName() { return displayName; }
+
+    @Override
+    public void setDisplayName(String name) { this.displayName = name; }
+
+    @Override
+    public PaintElement duplicate() {
+        FreehandElement copy = new FreehandElement(points, strokeColor, strokeWidth);
+        copy.setShadow(hasShadow);
+        copy.setDisplayName(displayName);
+        return copy;
+    }
+}


### PR DESCRIPTION
This pull request adds support for two new drawing tools: freehand and Bezier curve drawing. It introduces all necessary UI, event handling, and rendering logic to allow users to draw freehand lines and smooth Bezier curves interactively, including live previews and keyboard controls. The changes also add polyline simplification for freehand input and ensure the new tools integrate smoothly with the toolbox and main application.

**New Drawing Tools and User Interaction:**

- Added freehand and Bezier curve tools to the `ToolboxFrame.ToolType` enum and ensured they are recognized throughout the application, including cursor updates. [[1]](diffhunk://#diff-37b97375138a8b2d6ab955f25eea595c38c9f215c72541dda46f1b9c0309a231L26-R26) [[2]](diffhunk://#diff-28e34c728e6620e4383e042a1249c5c00b9aa13c5a5c23f3d874088cc642b3f4R271-R272)
- Implemented mouse and keyboard event handling in `DrawingPanel` for starting, updating, finalizing, and canceling freehand and Bezier drawings. This includes support for right-click and double-click to finish Bezier curves, and ESC to cancel in-progress drawings. [[1]](diffhunk://#diff-27734868a02c2d1a374221bbb692f6e1ea83a6ec052b3b612166722a8b96995bR42-R45) [[2]](diffhunk://#diff-27734868a02c2d1a374221bbb692f6e1ea83a6ec052b3b612166722a8b96995bR100-R105) [[3]](diffhunk://#diff-27734868a02c2d1a374221bbb692f6e1ea83a6ec052b3b612166722a8b96995bR127) [[4]](diffhunk://#diff-27734868a02c2d1a374221bbb692f6e1ea83a6ec052b3b612166722a8b96995bR144-R147) [[5]](diffhunk://#diff-27734868a02c2d1a374221bbb692f6e1ea83a6ec052b3b612166722a8b96995bR165-R180) [[6]](diffhunk://#diff-27734868a02c2d1a374221bbb692f6e1ea83a6ec052b3b612166722a8b96995bR248-R257) [[7]](diffhunk://#diff-27734868a02c2d1a374221bbb692f6e1ea83a6ec052b3b612166722a8b96995bR303-R347) [[8]](diffhunk://#diff-27734868a02c2d1a374221bbb692f6e1ea83a6ec052b3b612166722a8b96995bR374-R393)

**Rendering and Preview Enhancements:**

- Updated `CanvasRenderer` to render live previews of in-progress freehand and Bezier curves, including anchor points for Bezier curves and smooth Catmull-Rom interpolation for Bezier preview paths. [[1]](diffhunk://#diff-186019dc303860b8420515ae1fadb61bac6938d87ca32de119d7d2c62aee73a1R10-R12) [[2]](diffhunk://#diff-186019dc303860b8420515ae1fadb61bac6938d87ca32de119d7d2c62aee73a1L34-R39) [[3]](diffhunk://#diff-186019dc303860b8420515ae1fadb61bac6938d87ca32de119d7d2c62aee73a1R181-R256)
- Modified the `paintComponent` method in `DrawingPanel` to pass new state for freehand and Bezier previews to the renderer.

**Shape Creation and Simplification:**

- Added `createFreehandElement` and `createBezierElement` methods to `ShapeCreationService`, with freehand input simplified using the Douglas-Peucker algorithm for smoother lines. [[1]](diffhunk://#diff-2ac4e13389568a9897aff8aa7ae0794146b5b76d4ce9069f03027b19e2f9a440R7-R14) [[2]](diffhunk://#diff-2ac4e13389568a9897aff8aa7ae0794146b5b76d4ce9069f03027b19e2f9a440R117-R172)

**Quality-of-life and Debugging Improvements:**

- Set a minimum distance between freehand points to avoid excessive point density and improve performance.
- Updated `.vscode/launch.json` to ensure the debuggee is terminated after debugging sessions for smoother development workflow.