### PR TITLE
Add multi-selection and improve layer controls

### DIFF
--- a/src/main/java/app/CanvasRenderer.java
+++ b/src/main/java/app/CanvasRenderer.java
@@ -28,6 +28,7 @@ public class CanvasRenderer {
             boolean antiAliasingActive,
             boolean rsInterfaceVisible,
             BufferedImage rsInterfaceImage,
+            List<PaintElement> selectedElements,
             PaintElement selectedElementForMove,
             Point startPoint,
             Point endPoint,
@@ -64,17 +65,30 @@ public class CanvasRenderer {
             }
         }
 
-        if (toolboxFrame != null && toolboxFrame.getSelectedTool() == ToolboxFrame.ToolType.MOVE && selectedElementForMove != null) {
-            Rectangle bounds = selectedElementForMove.getBounds();
-            if (bounds != null) {
-                g2d.setColor(Color.BLUE);
-                float[] dash = {4f, 4f};
-                Stroke oldStroke = g2d.getStroke();
-                g2d.setStroke(new BasicStroke(1.5f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10f, dash, 0f));
-                g2d.drawRect(bounds.x - 2, bounds.y - 2, bounds.width + 4, bounds.height + 4);
-                g2d.setStroke(oldStroke);
+        if (selectedElements != null && !selectedElements.isEmpty()) {
+            g2d.setColor(Color.BLUE);
+            float[] dash = {4f, 4f};
+            Stroke oldStroke = g2d.getStroke();
+            g2d.setStroke(new BasicStroke(1.5f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10f, dash, 0f));
 
-                if (selectedElementForMove.isResizable() && bounds.width > 0 && bounds.height > 0) {
+            for (PaintElement selectedElement : selectedElements) {
+                if (selectedElement == null) {
+                    continue;
+                }
+                Rectangle bounds = selectedElement.getBounds();
+                if (bounds != null) {
+                    g2d.drawRect(bounds.x - 2, bounds.y - 2, bounds.width + 4, bounds.height + 4);
+                }
+            }
+
+            g2d.setStroke(oldStroke);
+
+            if (toolboxFrame != null
+                    && toolboxFrame.getSelectedTool() == ToolboxFrame.ToolType.MOVE
+                    && selectedElements.size() == 1
+                    && selectedElementForMove != null) {
+                Rectangle bounds = selectedElementForMove.getBounds();
+                if (selectedElementForMove.isResizable() && bounds != null && bounds.width > 0 && bounds.height > 0) {
                     drawResizeHandles(g2d, bounds);
                 }
             }

--- a/src/main/java/app/DrawingController.java
+++ b/src/main/java/app/DrawingController.java
@@ -3,7 +3,12 @@ package app;
 import java.awt.Cursor;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import javax.swing.JPanel;
 
@@ -16,7 +21,9 @@ public class DrawingController {
     private final Main host;
 
     private Point dragOffset;
+    private final Map<PaintElement, Point> dragOffsets = new HashMap<>();
     private PaintElement selectedElementForMove;
+    private final Set<PaintElement> selectedElements = new LinkedHashSet<>();
     private ResizeHandle activeResizeHandle = ResizeHandle.NONE;
     private Rectangle resizeStartBounds;
     private boolean minSizeReachedDuringResize;
@@ -41,7 +48,48 @@ public class DrawingController {
         return selectedElementForMove;
     }
 
+    public List<PaintElement> getSelectedElements() {
+        return new ArrayList<>(selectedElements);
+    }
+
+    public void selectSingleElement(PaintElement element) {
+        setSingleSelection(element);
+    }
+
+    public void setSelection(List<PaintElement> elements, PaintElement primaryElement) {
+        selectedElements.clear();
+        if (elements != null) {
+            for (PaintElement element : elements) {
+                if (element != null) {
+                    selectedElements.add(element);
+                }
+            }
+        }
+
+        if (primaryElement != null && selectedElements.contains(primaryElement)) {
+            selectedElementForMove = primaryElement;
+        } else {
+            syncPrimarySelection();
+        }
+    }
+
+    public void pruneSelection(List<PaintElement> currentElements) {
+        if (currentElements == null) {
+            selectedElements.clear();
+            dragOffsets.clear();
+            selectedElementForMove = null;
+            activeResizeHandle = ResizeHandle.NONE;
+            resizeStartBounds = null;
+            dragOffset = null;
+            return;
+        }
+        selectedElements.removeIf(e -> e == null || !currentElements.contains(e));
+        syncPrimarySelection();
+    }
+
     public void clearSelection(JPanel panel) {
+        selectedElements.clear();
+        dragOffsets.clear();
         selectedElementForMove = null;
         activeResizeHandle = ResizeHandle.NONE;
         resizeStartBounds = null;
@@ -59,7 +107,10 @@ public class DrawingController {
             return;
         }
 
-        if (activeResizeHandle != ResizeHandle.NONE && resizeStartBounds != null && selectedElementForMove.isResizable()) {
+        if (selectedElements.size() == 1
+                && activeResizeHandle != ResizeHandle.NONE
+                && resizeStartBounds != null
+                && selectedElementForMove.isResizable()) {
             Point resizePoint = currentPoint;
             if (host.isSnapToGridActive() && host.getGridManager().isGridVisible()) {
                 resizePoint = snapPointToGrid(resizePoint);
@@ -73,27 +124,35 @@ public class DrawingController {
             return;
         }
 
-        if (dragOffset != null) {
-            int newX = currentPoint.x - dragOffset.x;
-            int newY = currentPoint.y - dragOffset.y;
+        if (!dragOffsets.isEmpty()) {
+            for (PaintElement element : selectedElements) {
+                Point offset = dragOffsets.get(element);
+                if (offset == null) {
+                    continue;
+                }
 
-            if (host.isSnapToGridActive() && host.getGridManager().isGridVisible()) {
-                Point snappedPosition = snapPointToGrid(new Point(newX, newY));
-                selectedElementForMove.setPosition(snappedPosition.x, snappedPosition.y);
-            } else {
-                selectedElementForMove.setPosition(newX, newY);
+                int newX = currentPoint.x - offset.x;
+                int newY = currentPoint.y - offset.y;
+
+                if (host.isSnapToGridActive() && host.getGridManager().isGridVisible()) {
+                    Point snappedPosition = snapPointToGrid(new Point(newX, newY));
+                    element.setPosition(snappedPosition.x, snappedPosition.y);
+                } else {
+                    element.setPosition(newX, newY);
+                }
             }
             host.repaintDrawingPanel();
         }
     }
 
-    public void handleMousePressed(Point currentPoint, JPanel panel) {
+    public void handleMousePressed(Point currentPoint, JPanel panel, boolean ctrlDown) {
         activeResizeHandle = ResizeHandle.NONE;
         resizeStartBounds = null;
         dragOffset = null;
+        dragOffsets.clear();
         minSizeReachedDuringResize = false;
 
-        if (selectedElementForMove != null && selectedElementForMove.isResizable()) {
+        if (selectedElements.size() == 1 && selectedElementForMove != null && selectedElementForMove.isResizable()) {
             Rectangle selectedBounds = selectedElementForMove.getBounds();
             ResizeHandle clickedHandle = getResizeHandleAtPoint(currentPoint, selectedBounds);
             if (clickedHandle != ResizeHandle.NONE) {
@@ -108,20 +167,26 @@ public class DrawingController {
         List<PaintElement> paintElements = host.getPaintElements();
         PaintElement hitElement = findTopmostElementAt(currentPoint, paintElements);
         if (hitElement != null) {
-            selectedElementForMove = hitElement;
-            Point elementPos = selectedElementForMove.getPosition();
-            dragOffset = new Point(currentPoint.x - elementPos.x, currentPoint.y - elementPos.y);
-
-            ToolboxFrame toolbox = host.getToolboxFrame();
-            if (toolbox != null) {
-                int hitIndex = paintElements.indexOf(hitElement);
-                if (hitIndex >= 0) {
-                    int layerIndex = paintElements.size() - 1 - hitIndex;
-                    toolbox.selectLayerInList(layerIndex);
-                }
+            if (ctrlDown) {
+                toggleSelection(hitElement);
+                host.syncLayerSelectionWithCanvasSelection();
+                host.repaintDrawingPanel();
+                return;
             }
+
+            if (selectedElements.contains(hitElement)) {
+                selectedElementForMove = hitElement;
+            } else {
+                setSingleSelection(hitElement);
+            }
+
+            initializeGroupDragOffsets(currentPoint);
+            host.syncLayerSelectionWithCanvasSelection();
         } else {
-            selectedElementForMove = null;
+            if (!ctrlDown) {
+                setSingleSelection(null);
+                host.syncLayerSelectionWithCanvasSelection();
+            }
         }
         host.repaintDrawingPanel();
     }
@@ -141,18 +206,26 @@ public class DrawingController {
             return;
         }
 
-        if (selectedElementForMove != null && dragOffset != null) {
-            int newX = currentPoint.x - dragOffset.x;
-            int newY = currentPoint.y - dragOffset.y;
-            Point finalElementPos = new Point(newX, newY);
+        if (!dragOffsets.isEmpty()) {
+            for (PaintElement element : selectedElements) {
+                Point offset = dragOffsets.get(element);
+                if (offset == null) {
+                    continue;
+                }
 
-            if (host.isSnapToGridActive() && host.getGridManager().isGridVisible()) {
-                finalElementPos = snapPointToGrid(finalElementPos);
+                int newX = currentPoint.x - offset.x;
+                int newY = currentPoint.y - offset.y;
+                Point finalElementPos = new Point(newX, newY);
+
+                if (host.isSnapToGridActive() && host.getGridManager().isGridVisible()) {
+                    finalElementPos = snapPointToGrid(finalElementPos);
+                }
+                element.setPosition(finalElementPos.x, finalElementPos.y);
             }
-            selectedElementForMove.setPosition(finalElementPos.x, finalElementPos.y);
         }
 
         dragOffset = null;
+        dragOffsets.clear();
         updateMoveCursor(currentPoint, panel);
         host.repaintDrawingPanel();
     }
@@ -301,7 +374,7 @@ public class DrawingController {
             return;
         }
 
-        if (selectedElementForMove != null && selectedElementForMove.isResizable()) {
+        if (selectedElements.size() == 1 && selectedElementForMove != null && selectedElementForMove.isResizable()) {
             Rectangle bounds = selectedElementForMove.getBounds();
             ResizeHandle hoverHandle = getResizeHandleAtPoint(point, bounds);
             if (hoverHandle != ResizeHandle.NONE) {
@@ -316,5 +389,56 @@ public class DrawingController {
         } else {
             panel.setCursor(Cursor.getDefaultCursor());
         }
+    }
+
+    private void setSingleSelection(PaintElement element) {
+        selectedElements.clear();
+        if (element != null) {
+            selectedElements.add(element);
+        }
+        syncPrimarySelection();
+    }
+
+    private void toggleSelection(PaintElement element) {
+        if (element == null) {
+            return;
+        }
+
+        if (selectedElements.contains(element)) {
+            selectedElements.remove(element);
+        } else {
+            selectedElements.add(element);
+            selectedElementForMove = element;
+        }
+        syncPrimarySelection();
+    }
+
+    private void initializeGroupDragOffsets(Point currentPoint) {
+        dragOffsets.clear();
+        for (PaintElement element : selectedElements) {
+            Point elementPos = element.getPosition();
+            dragOffsets.put(element, new Point(currentPoint.x - elementPos.x, currentPoint.y - elementPos.y));
+        }
+
+        if (selectedElementForMove != null) {
+            Point primaryPos = selectedElementForMove.getPosition();
+            dragOffset = new Point(currentPoint.x - primaryPos.x, currentPoint.y - primaryPos.y);
+        }
+    }
+
+    private void syncPrimarySelection() {
+        if (selectedElements.isEmpty()) {
+            selectedElementForMove = null;
+            activeResizeHandle = ResizeHandle.NONE;
+            resizeStartBounds = null;
+            dragOffset = null;
+            dragOffsets.clear();
+            return;
+        }
+
+        if (selectedElementForMove != null && selectedElements.contains(selectedElementForMove)) {
+            return;
+        }
+        selectedElementForMove = selectedElements.iterator().next();
     }
 }

--- a/src/main/java/app/DrawingPanel.java
+++ b/src/main/java/app/DrawingPanel.java
@@ -120,7 +120,7 @@ public class DrawingPanel extends JPanel {
                 Point currentPoint = e.getPoint();
 
                 if (selectedTool == ToolboxFrame.ToolType.MOVE) {
-                    drawingController.handleMousePressed(currentPoint, DrawingPanel.this);
+                    drawingController.handleMousePressed(currentPoint, DrawingPanel.this, e.isControlDown());
                     return;
                 }
 
@@ -412,6 +412,7 @@ public class DrawingPanel extends JPanel {
                 host.isAntiAliasingActive(),
                 host.isDrawRSInterfaceVisible(),
                 host.getRsInterfaceImage(),
+                drawingController.getSelectedElements(),
                 drawingController.getSelectedElementForMove(),
                 startPoint,
                 endPoint,

--- a/src/main/java/app/ElementService.java
+++ b/src/main/java/app/ElementService.java
@@ -11,7 +11,7 @@ public class ElementService {
     }
 
     public int toPaintElementIndex(int paintElementCount, int toolboxIndex) {
-        return paintElementCount - 1 - toolboxIndex;
+        return toolboxIndex;
     }
 
     public void moveElement(List<PaintElement> elements, int fromIndex, int toIndex) {

--- a/src/main/java/app/Main.java
+++ b/src/main/java/app/Main.java
@@ -22,7 +22,9 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.net.URL;
 import org.slf4j.Logger;
@@ -331,16 +333,17 @@ public class Main extends JFrame {
     }
 
     public void updateToolboxLayerList() {
+        drawingController.pruneSelection(paintElements);
         if (toolboxFrame != null) {
             List<String> layerNames = paintElements.stream()
                                                  .map(this::getEffectiveDisplayName)
                                                  .collect(Collectors.toList());
             int size = layerNames.size();
             for (int i = 0; i < size; i++) {
-                layerNames.set(i, String.format("[%d] %s", size - 1 - i, layerNames.get(i)));
+                layerNames.set(i, String.format("[%d] %s", size - i, layerNames.get(i)));
             }
-            Collections.reverse(layerNames); // To display top layer at the top of the list
             toolboxFrame.updateLayersList(layerNames);
+            syncLayerSelectionWithCanvasSelection();
         }
     }
 
@@ -469,6 +472,38 @@ public class Main extends JFrame {
         }
     }
 
+    public void deletePaintElements(int[] selectedIndicesInListModel) {
+        if (selectedIndicesInListModel == null || selectedIndicesInListModel.length == 0) {
+            return;
+        }
+
+        int[] sortedDescending = java.util.Arrays.stream(selectedIndicesInListModel)
+                .distinct()
+                .boxed()
+                .sorted(java.util.Collections.reverseOrder())
+                .mapToInt(Integer::intValue)
+                .toArray();
+
+        int removedCount = 0;
+        for (int index : sortedDescending) {
+            if (index < 0 || index >= paintElements.size()) {
+                continue;
+            }
+
+            PaintElement removedElement = paintElements.get(index);
+            UndoableAction action = new DeleteElementAction(this, removedElement, index);
+            paintElements.remove(index);
+            addUndoableAction(action);
+            removedCount++;
+        }
+
+        if (removedCount > 0) {
+            updateToolboxLayerList();
+            repaintDrawingPanel();
+            setLastActionStatus("Deleted " + removedCount + " layer(s)");
+        }
+    }
+
     public void duplicatePaintElement(int selectedIndexInListModel) {
         logger.debug("duplicatePaintElement called with selectedIndexInListModel={}", selectedIndexInListModel);
         if (toolboxFrame == null || selectedIndexInListModel < 0 || selectedIndexInListModel >= toolboxFrame.getLayersListModel().getSize()) {
@@ -506,6 +541,55 @@ public class Main extends JFrame {
         repaintDrawingPanel();
         setLastActionStatus("Duplicated '" + uniqueDisplayName + "'");
         logger.info("Element '{}' duplicated as '{}' at offset ({}, {})", originalElement.getDisplayName(), uniqueDisplayName, offsetX, offsetY);
+    }
+
+    public void duplicatePaintElements(int[] selectedIndicesInListModel) {
+        if (selectedIndicesInListModel == null || selectedIndicesInListModel.length == 0) {
+            return;
+        }
+
+        int[] sortedAscending = java.util.Arrays.stream(selectedIndicesInListModel)
+                .distinct()
+                .sorted()
+                .toArray();
+
+        List<PaintElement> duplicates = new ArrayList<>();
+        for (int selectedIndex : sortedAscending) {
+            if (selectedIndex < 0 || selectedIndex >= paintElements.size()) {
+                continue;
+            }
+
+            PaintElement originalElement = paintElements.get(selectedIndex);
+            if (originalElement == null) {
+                continue;
+            }
+
+            PaintElement duplicatedElement = originalElement.duplicate();
+            if (duplicatedElement == null) {
+                continue;
+            }
+
+            Point originalPosition = duplicatedElement.getPosition();
+            int offsetX = 10;
+            int offsetY = 10;
+            duplicatedElement.setPosition(originalPosition.x + offsetX, originalPosition.y + offsetY);
+            String uniqueDisplayName = generateUniqueDisplayName(duplicatedElement.getName());
+            duplicatedElement.setDisplayName(uniqueDisplayName);
+            duplicates.add(duplicatedElement);
+        }
+
+        if (duplicates.isEmpty()) {
+            return;
+        }
+
+        paintElements.addAll(0, duplicates);
+
+        List<PaintElement> selectedDupes = new ArrayList<>(duplicates);
+        drawingController.setSelection(selectedDupes, selectedDupes.get(0));
+
+        updateToolboxLayerList();
+        repaintDrawingPanel();
+        setLastActionStatus("Duplicated " + duplicates.size() + " layer(s)");
     }
 
     public void updatePaintElementDisplayName(int listIndexInToolbox, String newDisplayName) {
@@ -570,6 +654,59 @@ public class Main extends JFrame {
             setLastActionStatus("Reordered layer: '" + element.getDisplayName() + "'");
         } else {
             logger.error("Main.moveLayerDown: Invalid index: " + listIndexInToolbox);
+        }
+    }
+
+    public void moveLayersUp(int[] selectedIndicesInListModel) {
+        if (selectedIndicesInListModel == null || selectedIndicesInListModel.length == 0) {
+            return;
+        }
+
+        java.util.Set<Integer> selectedSet = java.util.Arrays.stream(selectedIndicesInListModel)
+                .boxed()
+                .collect(Collectors.toSet());
+        int[] sortedAscending = selectedSet.stream().sorted().mapToInt(Integer::intValue).toArray();
+
+        boolean moved = false;
+        for (int index : sortedAscending) {
+            if (index > 0 && !selectedSet.contains(index - 1)) {
+                Collections.swap(paintElements, index, index - 1);
+                moved = true;
+            }
+        }
+
+        if (moved) {
+            updateToolboxLayerList();
+            repaintDrawingPanel();
+            setLastActionStatus("Moved selection up");
+        }
+    }
+
+    public void moveLayersDown(int[] selectedIndicesInListModel) {
+        if (selectedIndicesInListModel == null || selectedIndicesInListModel.length == 0) {
+            return;
+        }
+
+        java.util.Set<Integer> selectedSet = java.util.Arrays.stream(selectedIndicesInListModel)
+                .boxed()
+                .collect(Collectors.toSet());
+        int[] sortedDescending = selectedSet.stream()
+                .sorted(Collections.reverseOrder())
+                .mapToInt(Integer::intValue)
+                .toArray();
+
+        boolean moved = false;
+        for (int index : sortedDescending) {
+            if (index < paintElements.size() - 1 && !selectedSet.contains(index + 1)) {
+                Collections.swap(paintElements, index, index + 1);
+                moved = true;
+            }
+        }
+
+        if (moved) {
+            updateToolboxLayerList();
+            repaintDrawingPanel();
+            setLastActionStatus("Moved selection down");
         }
     }
 
@@ -732,6 +869,43 @@ public class Main extends JFrame {
         return paintElements;
     }
 
+    public List<PaintElement> getSelectedPaintElements() {
+        return drawingController.getSelectedElements();
+    }
+
+    public PaintElement getPrimarySelectedPaintElement() {
+        return drawingController.getSelectedElementForMove();
+    }
+
+    public void syncLayerSelectionWithCanvasSelection() {
+        if (toolboxFrame == null) {
+            return;
+        }
+
+        List<PaintElement> selected = drawingController.getSelectedElements();
+        PaintElement primary = drawingController.getSelectedElementForMove();
+
+        if (selected.isEmpty()) {
+            toolboxFrame.clearLayerSelection();
+            return;
+        }
+
+        List<Integer> selectedPaintIndices = new ArrayList<>();
+        for (PaintElement element : selected) {
+            int idx = paintElements.indexOf(element);
+            if (idx >= 0) {
+                selectedPaintIndices.add(idx);
+            }
+        }
+
+        int primaryIndex = paintElements.indexOf(primary);
+        if (primaryIndex < 0 && !selectedPaintIndices.isEmpty()) {
+            primaryIndex = selectedPaintIndices.get(0);
+        }
+
+        toolboxFrame.selectLayersInList(selectedPaintIndices, primaryIndex);
+    }
+
     // Add this stub for MoveElementAction (returns null for now, or implement selection logic if needed)
     public PaintElement getCurrentlySelectedElementInList() {
         // If you have a selection model in ToolboxFrame, return the selected element here
@@ -754,8 +928,29 @@ public class Main extends JFrame {
     }
 
     // For ToolboxFrame
-    public void handleLayerSelectionChanged(int selectedIndex) {
-        // Optionally, update UI or selection state. No-op stub for now.
+    public void handleLayerSelectionChanged(int[] selectedIndices, int leadIndex) {
+        if (selectedIndices == null || selectedIndices.length == 0) {
+            drawingController.clearSelection(drawingPanel);
+            repaintDrawingPanel();
+            return;
+        }
+
+        Set<PaintElement> orderedSelected = new LinkedHashSet<>();
+        for (int selectedIndex : selectedIndices) {
+            int paintElementIndex = selectedIndex;
+            if (paintElementIndex >= 0 && paintElementIndex < paintElements.size()) {
+                orderedSelected.add(paintElements.get(paintElementIndex));
+            }
+        }
+
+        int primaryPaintElementIndex = leadIndex;
+        PaintElement primary = null;
+        if (primaryPaintElementIndex >= 0 && primaryPaintElementIndex < paintElements.size()) {
+            primary = paintElements.get(primaryPaintElementIndex);
+        }
+
+        drawingController.setSelection(new ArrayList<>(orderedSelected), primary);
+        repaintDrawingPanel();
     }
 
     public void updateFrameTitle() {

--- a/src/main/java/app/ToolboxFrame.java
+++ b/src/main/java/app/ToolboxFrame.java
@@ -40,6 +40,7 @@ public class ToolboxFrame extends JFrame {
 
     private DefaultListModel<String> layersModel = new DefaultListModel<>();
     private JList<String> layersList; // Made layersList a field to access it for selection
+    private boolean suppressLayerSelectionEvents = false;
 
     // Fields for remaining controls
     private boolean isFillEnabled = true;
@@ -287,7 +288,7 @@ public class ToolboxFrame extends JFrame {
         layersPanel.setLayout(new BoxLayout(layersPanel, BoxLayout.Y_AXIS));
         layersPanel.setBorder(BorderFactory.createTitledBorder("Layers:"));
         layersList = new JList<>(layersModel);
-        layersList.setSelectionMode(ListSelectionModel.SINGLE_SELECTION); // Ensure single selection
+        layersList.setSelectionMode(ListSelectionModel.MULTIPLE_INTERVAL_SELECTION);
         // Initialize buttons here so the listener can access them
         JButton upBtn = createLayerButton("Move Layer Up", "/img/ui/layer-up.png", "▲");
         JButton downBtn = createLayerButton("Move Layer Down", "/img/ui/layer-down.png", "▼");
@@ -299,25 +300,37 @@ public class ToolboxFrame extends JFrame {
         layersList.addListSelectionListener(new ListSelectionListener() {
             @Override
             public void valueChanged(ListSelectionEvent e) {
-                if (!e.getValueIsAdjusting()) {
-                    int selectedIndex = layersList.getSelectedIndex();
-                    boolean isSelected = selectedIndex != -1;
-                    
-                    editBtn.setEnabled(isSelected);
-                    deleteBtn.setEnabled(isSelected);
-                    duplicateBtn.setEnabled(isSelected);
+                if (!e.getValueIsAdjusting() && !suppressLayerSelectionEvents) {
+                    int[] selectedIndices = layersList.getSelectedIndices();
+                    int selectedCount = selectedIndices.length;
+                    boolean anySelected = selectedCount > 0;
+                    boolean singleSelected = selectedCount == 1;
+
+                    editBtn.setEnabled(singleSelected);
+                    deleteBtn.setEnabled(anySelected);
+                    duplicateBtn.setEnabled(anySelected);
                     clearBtn.setEnabled(!layersModel.isEmpty());
 
-                    if (isSelected) {
-                        upBtn.setEnabled(selectedIndex > 0);
-                        downBtn.setEnabled(selectedIndex < layersModel.getSize() - 1);
+                    if (anySelected) {
+                        boolean canMoveUp = false;
+                        boolean canMoveDown = false;
+                        for (int selectedIndex : selectedIndices) {
+                            if (selectedIndex > 0) {
+                                canMoveUp = true;
+                            }
+                            if (selectedIndex < layersModel.getSize() - 1) {
+                                canMoveDown = true;
+                            }
+                        }
+                        upBtn.setEnabled(canMoveUp);
+                        downBtn.setEnabled(canMoveDown);
                     } else {
                         upBtn.setEnabled(false);
                         downBtn.setEnabled(false);
                     }
-                    // Notify Main frame of selection change
+
                     if (mainFrame != null) {
-                        mainFrame.handleLayerSelectionChanged(selectedIndex);
+                        mainFrame.handleLayerSelectionChanged(selectedIndices, layersList.getLeadSelectionIndex());
                     }
                 }
             }
@@ -338,12 +351,9 @@ public class ToolboxFrame extends JFrame {
         clearBtn.setEnabled(false);
 
         duplicateBtn.addActionListener(e -> { // Changed from addBtn
-            int selectedIndex = layersList.getSelectedIndex();
-            if (selectedIndex != -1) {
-                // Instruct Main to duplicate the element
-                mainFrame.duplicatePaintElement(selectedIndex);
-                // Main.duplicatePaintElement will handle adding the new layer to the list
-                // and selecting it.
+            int[] selectedIndices = layersList.getSelectedIndices();
+            if (selectedIndices.length > 0) {
+                mainFrame.duplicatePaintElements(selectedIndices);
             } else {
                 JOptionPane.showMessageDialog(ToolboxFrame.this, "Please select a layer to duplicate.", "No Layer Selected", JOptionPane.INFORMATION_MESSAGE);
             }
@@ -387,43 +397,33 @@ public class ToolboxFrame extends JFrame {
         });
 
         deleteBtn.addActionListener(e -> {
-            int selectedIndex = layersList.getSelectedIndex();
-            if (selectedIndex != -1) {
-                String layerName = layersModel.getElementAt(selectedIndex);
+            int[] selectedIndices = layersList.getSelectedIndices();
+            if (selectedIndices.length > 0) {
+                String layerName = selectedIndices.length == 1
+                        ? layersModel.getElementAt(selectedIndices[0])
+                        : selectedIndices.length + " selected layers";
                 int confirm = JOptionPane.showConfirmDialog(ToolboxFrame.this,
                         "Are you sure you want to delete layer '" + layerName + "'?",
                         "Delete Layer",
                         JOptionPane.YES_NO_OPTION);
                 if (confirm == JOptionPane.YES_OPTION) {
-                    // Notify Main to remove the corresponding PaintElement
-                    // Main will then update the layersModel via updateToolboxLayerList
-                    mainFrame.deletePaintElement(selectedIndex);
-                    logger.info("Delete request for layer: " + layerName + " at JList index " + selectedIndex);
+                    mainFrame.deletePaintElements(selectedIndices);
+                    logger.info("Delete request for {} layer(s)", selectedIndices.length);
                 }
             }
         });
 
         upBtn.addActionListener(e -> {
-            int selectedIndex = layersList.getSelectedIndex();
-            if (selectedIndex > 0) {
-                String temp = layersModel.getElementAt(selectedIndex);
-                layersModel.setElementAt(layersModel.getElementAt(selectedIndex - 1), selectedIndex);
-                layersModel.setElementAt(temp, selectedIndex - 1);
-                layersList.setSelectedIndex(selectedIndex - 1);
-                mainFrame.moveLayerUp(selectedIndex); // Notify Main to reorder PaintElement
-                logger.info("Moved layer up: " + temp + " from index " + selectedIndex);
+            int[] selectedIndices = layersList.getSelectedIndices();
+            if (selectedIndices.length > 0) {
+                mainFrame.moveLayersUp(selectedIndices);
             }
         });
 
         downBtn.addActionListener(e -> {
-            int selectedIndex = layersList.getSelectedIndex();
-            if (selectedIndex != -1 && selectedIndex < layersModel.getSize() - 1) {
-                String temp = layersModel.getElementAt(selectedIndex);
-                layersModel.setElementAt(layersModel.getElementAt(selectedIndex + 1), selectedIndex);
-                layersModel.setElementAt(temp, selectedIndex + 1);
-                layersList.setSelectedIndex(selectedIndex + 1);
-                mainFrame.moveLayerDown(selectedIndex); // Notify Main to reorder PaintElement
-                logger.info("Moved layer down: " + temp + " from index " + selectedIndex);
+            int[] selectedIndices = layersList.getSelectedIndices();
+            if (selectedIndices.length > 0) {
+                mainFrame.moveLayersDown(selectedIndices);
             }
         });
 
@@ -899,23 +899,64 @@ public class ToolboxFrame extends JFrame {
     // Method to update the entire layers list from a list of names
     public void updateLayersList(java.util.List<String> layerNames) {
         layersModel.clear();
-        // Add in reverse order so topmost (last in list) is at index 0 (top of JList)
-        for (int i = layerNames.size() - 1; i >= 0; i--) {
-            layersModel.addElement(layerNames.get(i));
+        for (String layerName : layerNames) {
+            layersModel.addElement(layerName);
         }
     }
 
     // Method to select a layer in the list by index (from paintElements list)
     public void selectLayerInList(int paintElementIndex) {
-        int jListIndex = layersModel.size() - 1 - paintElementIndex;
+        int jListIndex = paintElementIndex;
         if (layersList != null && jListIndex >= 0 && jListIndex < layersModel.size()) {
-            layersList.setSelectedIndex(jListIndex);
-            layersList.ensureIndexIsVisible(jListIndex);
+            suppressLayerSelectionEvents = true;
+            try {
+                layersList.setSelectedIndex(jListIndex);
+                layersList.ensureIndexIsVisible(jListIndex);
+            } finally {
+                suppressLayerSelectionEvents = false;
+            }
+        }
+    }
+
+    public void selectLayersInList(java.util.List<Integer> paintElementIndices, int primaryPaintElementIndex) {
+        if (layersList == null) {
+            return;
+        }
+
+        suppressLayerSelectionEvents = true;
+        try {
+            layersList.clearSelection();
+            if (paintElementIndices == null || paintElementIndices.isEmpty()) {
+                return;
+            }
+
+            for (Integer paintIndex : paintElementIndices) {
+                if (paintIndex == null) {
+                    continue;
+                }
+                int jListIndex = paintIndex;
+                if (jListIndex >= 0 && jListIndex < layersModel.size()) {
+                    layersList.addSelectionInterval(jListIndex, jListIndex);
+                }
+            }
+
+            int leadIndex = primaryPaintElementIndex;
+            if (leadIndex >= 0 && leadIndex < layersModel.size()) {
+                layersList.getSelectionModel().setLeadSelectionIndex(leadIndex);
+                layersList.ensureIndexIsVisible(leadIndex);
+            }
+        } finally {
+            suppressLayerSelectionEvents = false;
         }
     }
 
     public void clearLayerSelection() {
-        layersList.clearSelection();
+        suppressLayerSelectionEvents = true;
+        try {
+            layersList.clearSelection();
+        } finally {
+            suppressLayerSelectionEvents = false;
+        }
     }
 
     // Method to clear all layers from the list


### PR DESCRIPTION
This pull request introduces multi-selection support for paint elements in the drawing application, enabling users to select, move, delete, and duplicate multiple elements at once. The changes include updates to selection logic, drag-and-drop handling, UI rendering, and batch operations for deletion and duplication. These improvements enhance the user experience by allowing more flexible and efficient manipulation of multiple elements.

**Multi-selection and selection management:**

* Added a `selectedElements` set and related methods to `DrawingController` to support multiple selected paint elements, including logic for toggling, pruning, and syncing selection, as well as group drag offsets for moving multiple elements together. [[1]](diffhunk://#diff-f32483ffc6660fbb97993c076edb2d95fac36b74148bab2353fd4a3c695d1bc0R24-R26) [[2]](diffhunk://#diff-f32483ffc6660fbb97993c076edb2d95fac36b74148bab2353fd4a3c695d1bc0R51-R92) [[3]](diffhunk://#diff-f32483ffc6660fbb97993c076edb2d95fac36b74148bab2353fd4a3c695d1bc0L76-R155) [[4]](diffhunk://#diff-f32483ffc6660fbb97993c076edb2d95fac36b74148bab2353fd4a3c695d1bc0L111-R189) [[5]](diffhunk://#diff-f32483ffc6660fbb97993c076edb2d95fac36b74148bab2353fd4a3c695d1bc0R393-R443)
* Updated mouse event handling in `DrawingController` and `DrawingPanel` to allow Ctrl+click for multi-selection and proper selection state updates on mouse actions. [[1]](diffhunk://#diff-f32483ffc6660fbb97993c076edb2d95fac36b74148bab2353fd4a3c695d1bc0L111-R189) [[2]](diffhunk://#diff-27734868a02c2d1a374221bbb692f6e1ea83a6ec052b3b612166722a8b96995bL123-R123)

**Rendering and UI updates:**

* Modified `CanvasRenderer` and `DrawingPanel` to visually indicate all selected elements by drawing selection rectangles around each, and to only show resize handles when a single, resizable element is selected. [[1]](diffhunk://#diff-186019dc303860b8420515ae1fadb61bac6938d87ca32de119d7d2c62aee73a1R31) [[2]](diffhunk://#diff-186019dc303860b8420515ae1fadb61bac6938d87ca32de119d7d2c62aee73a1L67-R91) [[3]](diffhunk://#diff-27734868a02c2d1a374221bbb692f6e1ea83a6ec052b3b612166722a8b96995bR415)
* Updated cursor and resize logic to be consistent with multi-selection, only allowing resizing when a single element is selected. [[1]](diffhunk://#diff-f32483ffc6660fbb97993c076edb2d95fac36b74148bab2353fd4a3c695d1bc0L62-R113) [[2]](diffhunk://#diff-f32483ffc6660fbb97993c076edb2d95fac36b74148bab2353fd4a3c695d1bc0L304-R377)

**Batch operations for elements:**

* Added batch deletion (`deletePaintElements`) and duplication (`duplicatePaintElements`) methods in `Main`, allowing users to delete or duplicate multiple selected layers at once, with appropriate undo support and UI feedback. [[1]](diffhunk://#diff-28e34c728e6620e4383e042a1249c5c00b9aa13c5a5c23f3d874088cc642b3f4R475-R506) [[2]](diffhunk://#diff-28e34c728e6620e4383e042a1249c5c00b9aa13c5a5c23f3d874088cc642b3f4R546-R594)

**Selection synchronization and layer list updates:**

* Ensured toolbox layer list and selection state stay in sync with canvas selection, including pruning invalid selections when layers change.

**Indexing and display adjustments:**

* Fixed element index conversion and layer naming in `ElementService` and `Main` to improve consistency and clarity in the UI. [[1]](diffhunk://#diff-b0b14d6efff4cf6184035369131470df0b68566ed140a61b8e233f3e37385cc0L14-R14) [[2]](diffhunk://#diff-28e34c728e6620e4383e042a1249c5c00b9aa13c5a5c23f3d874088cc642b3f4R336-R346)

These changes collectively provide a more powerful and user-friendly interface for managing multiple paint elements in the application.